### PR TITLE
Add portfolio slide deck generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ adk eval \
     samples_for_testing/hello_world/hello_world_eval_set_001.evalset.json
 ```
 
+## 📊 Portfolio Slide Deck Example
+
+This repository includes a small script that generates a web-based slide deck
+showcasing recent web and mobile projects. The slide deck uses
+[Reveal.js](https://revealjs.com/) and loads screenshots from an online
+thumbnail service.
+
+To generate the deck run:
+
+```bash
+python scripts/generate_portfolio.py
+```
+
+The resulting `assets/portfolio/index.html` can be opened in any browser and
+displays a slide for each project.
+
 ## 🤝 Contributing
 
 We welcome contributions from the community! Whether it's bug reports, feature requests, documentation improvements, or code contributions, please see our

--- a/assets/portfolio/index.html
+++ b/assets/portfolio/index.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>Portfolio</title>
+  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.2/reveal.min.css'>
+  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.2/theme/black.min.css'>
+</head>
+<body>
+  <div class='reveal'>
+    <div class='slides'>
+<section><h1>Project Portfolio</h1><p>Web and Mobile Applications</p></section>
+
+<section>
+  <h2><a href="https://africamarkets.com/home">Africa Markets</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fafricamarkets.com%2Fhome" alt="Africa Markets screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://invest.accretivzone.com/">Accretiv Zone</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Finvest.accretivzone.com%2F" alt="Accretiv Zone screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://creincomefund.com/">CRE Income Fund</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fcreincomefund.com%2F" alt="CRE Income Fund screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://blockengine.io/">Block Engine</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fblockengine.io%2F" alt="Block Engine screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://usareit.com/">USA REIT</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fusareit.com%2F" alt="USA REIT screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://secondmarket.co.za/">Second Market</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fsecondmarket.co.za%2F" alt="Second Market screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://fundengine.io/">Fund Engine</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Ffundengine.io%2F" alt="Fund Engine screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://orbvest.com/">OrbVest</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Forbvest.com%2F" alt="OrbVest screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://www.leisureleagues.net/">Leisure Leagues</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fwww.leisureleagues.net%2F" alt="Leisure Leagues screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://enforma-venice.com/">Enforma Venice</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fenforma-venice.com%2F" alt="Enforma Venice screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://www.difiaba.com/">Difiaba</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fwww.difiaba.com%2F" alt="Difiaba screenshot" style="max-width:90%;height:auto;">
+  
+</section>
+
+<section>
+  <h2><a href="https://www.fashiongo.net/">Fashion Go</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fwww.fashiongo.net%2F" alt="Fashion Go screenshot" style="max-width:90%;height:auto;">
+  <p>Includes mobile apps</p>
+</section>
+
+<section>
+  <h2><a href="https://rentler.com.au/">Rentler AU</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Frentler.com.au%2F" alt="Rentler AU screenshot" style="max-width:90%;height:auto;">
+  <p>Includes mobile apps</p>
+</section>
+
+<section>
+  <h2><a href="https://myrentalspot.com/">My Rental Spot</a></h2>
+  <img src="https://image.thum.io/get/width/1280/https%3A%2F%2Fmyrentalspot.com%2F" alt="My Rental Spot screenshot" style="max-width:90%;height:auto;">
+  <p>Includes mobile apps</p>
+</section>
+    </div>
+  </div>
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.2/reveal.min.js'></script>
+  <script>Reveal.initialize();</script>
+</body>
+</html>

--- a/scripts/generate_portfolio.py
+++ b/scripts/generate_portfolio.py
@@ -1,0 +1,72 @@
+"""Generate an HTML portfolio slide deck.
+
+This script creates an index.html file under ``assets/portfolio`` which
+uses the Reveal.js presentation framework. Each slide shows a screenshot
+of a site along with a link to the live website. Screenshots are loaded
+from an online thumbnail service so no local browser automation is
+required.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import quote_plus
+
+PORTFOLIO_JSON = Path(__file__).with_name("portfolio_sites.json")
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "assets" / "portfolio"
+
+THUMB_URL = "https://image.thum.io/get/width/1280/{url}"
+
+
+def create_slide(site: dict[str, object]) -> str:
+    """Return HTML for a single slide."""
+    name = site["name"]
+    url = site["url"]
+    has_apps = site.get("apps", False)
+    screenshot = THUMB_URL.format(url=quote_plus(url))
+    apps_text = "<p>Includes mobile apps</p>" if has_apps else ""
+    return f"""
+<section>
+  <h2><a href=\"{url}\">{name}</a></h2>
+  <img src=\"{screenshot}\" alt=\"{name} screenshot\" style=\"max-width:90%;height:auto;\">
+  {apps_text}
+</section>"""
+
+
+def generate_html(sites: list[dict[str, object]]) -> str:
+    slides = [
+        "<section><h1>Project Portfolio</h1><p>Web and Mobile Applications</p></section>"
+    ]
+    for site in sites:
+        slides.append(create_slide(site))
+    slides_html = "\n".join(slides)
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>Portfolio</title>
+  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.2/reveal.min.css'>
+  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.2/theme/black.min.css'>
+</head>
+<body>
+  <div class='reveal'>
+    <div class='slides'>
+{slides_html}
+    </div>
+  </div>
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.6.2/reveal.min.js'></script>
+  <script>Reveal.initialize();</script>
+</body>
+</html>"""
+
+
+def main() -> None:
+    sites = json.loads(PORTFOLIO_JSON.read_text())
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    html = generate_html(sites)
+    (OUTPUT_DIR / "index.html").write_text(html)
+    print(f"Wrote {OUTPUT_DIR / 'index.html'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/portfolio_sites.json
+++ b/scripts/portfolio_sites.json
@@ -1,0 +1,16 @@
+[
+  {"name": "Africa Markets", "url": "https://africamarkets.com/home", "apps": false},
+  {"name": "Accretiv Zone", "url": "https://invest.accretivzone.com/", "apps": false},
+  {"name": "CRE Income Fund", "url": "https://creincomefund.com/", "apps": false},
+  {"name": "Block Engine", "url": "https://blockengine.io/", "apps": false},
+  {"name": "USA REIT", "url": "https://usareit.com/", "apps": false},
+  {"name": "Second Market", "url": "https://secondmarket.co.za/", "apps": false},
+  {"name": "Fund Engine", "url": "https://fundengine.io/", "apps": false},
+  {"name": "OrbVest", "url": "https://orbvest.com/", "apps": false},
+  {"name": "Leisure Leagues", "url": "https://www.leisureleagues.net/", "apps": false},
+  {"name": "Enforma Venice", "url": "https://enforma-venice.com/", "apps": false},
+  {"name": "Difiaba", "url": "https://www.difiaba.com/", "apps": false},
+  {"name": "Fashion Go", "url": "https://www.fashiongo.net/", "apps": true},
+  {"name": "Rentler AU", "url": "https://rentler.com.au/", "apps": true},
+  {"name": "My Rental Spot", "url": "https://myrentalspot.com/", "apps": true}
+]

--- a/tests/unittests/portfolio/test_generate_portfolio.py
+++ b/tests/unittests/portfolio/test_generate_portfolio.py
@@ -1,0 +1,9 @@
+from scripts import generate_portfolio as gp
+
+
+def test_generate_html_contains_project():
+    sites = [{"name": "Example", "url": "https://example.com", "apps": False}]
+    html = gp.generate_html(sites)
+    assert "Example" in html
+    assert "https://example.com" in html
+    assert gp.THUMB_URL.split('{')[0] in html


### PR DESCRIPTION
## Summary
- add a `generate_portfolio.py` script that builds a reveal.js slide deck
- list portfolio sites in `portfolio_sites.json`
- generate example `assets/portfolio/index.html`
- document portfolio deck generation in README
- test HTML generation

## Testing
- `pytest tests/unittests/portfolio/test_generate_portfolio.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684a984adb28832d986059abd5f545f7