### PR TITLE
chore: raise minimum Python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "google-adk"
 description = "Agent Development Kit"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 classifiers = [ # List of https://pypi.org/classifiers/
@@ -14,7 +14,6 @@ classifiers = [ # List of https://pypi.org/classifiers/
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -159,7 +158,7 @@ asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 exclude = "tests/"
 plugins = ["pydantic.mypy"]
 # Start with non-strict mode, and swtich to strict mode later.


### PR DESCRIPTION
### Motivation
- Raise the project's minimum supported Python version to 3.10 to align with dependency markers and modern typing/tooling targets.

### Description
- Updated `pyproject.toml` to set `requires-python = ">=3.10"`, removed the Python 3.9 classifier, and changed `[tool.mypy]` `python_version` to `3.10`.

### Testing
- No automated tests were executed because this is a metadata/configuration-only change; repository checks (`rg` and `git status`) were run to verify the edits were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0defa992e4832d838d187927b448bc)